### PR TITLE
Improve compare responsiveness, favorites empty state, and suggest dictionary manager

### DIFF
--- a/functions/api/suggest/manage.ts
+++ b/functions/api/suggest/manage.ts
@@ -1,0 +1,35 @@
+/// <reference lib="webworker" />
+/// <reference types="@cloudflare/workers-types" />
+
+export const onRequestGet: PagesFunction<{ PAIVIZ_LINKS: KVNamespace }> = async ({ env }) => {
+  try {
+    const txt = await env.PAIVIZ_LINKS.get("seed:players");
+    const seeds = txt ? JSON.parse(txt) : [];
+    return json({ seeds });
+  } catch {
+    return json({ seeds: [] });
+  }
+};
+
+export const onRequestPost: PagesFunction<{ PAIVIZ_LINKS: KVNamespace }> = async ({ request, env }) => {
+  try {
+    const body = await request.json();
+    if (!body || !Array.isArray(body.seeds)) throw new Error("invalid");
+    const seeds = body.seeds
+      .map((s: unknown) => String(s))
+      .filter((s: string) => s.length > 0);
+    await env.PAIVIZ_LINKS.put("seed:players", JSON.stringify(seeds));
+    return json({ ok: true });
+  } catch {
+    return json({ error: "bad_request" }, 400);
+  }
+};
+
+const json = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });

--- a/pages/compare.vue
+++ b/pages/compare.vue
@@ -2,7 +2,7 @@
   <section class="space-y-4">
     <div class="flex items-center justify-between">
       <h1 class="text-2xl font-bold">プレイヤー比較</h1>
-      <div class="flex items-center gap-2 text-sm text-muted">
+      <div class="flex flex-wrap items-center gap-2 text-sm text-muted">
         <button
           class="rounded-lg border border-border px-2 py-1 hover:text-text"
           @click="shareCurrent"
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    <div class="grid gap-2 md:grid-cols-2">
+    <div class="grid gap-2 lg:grid-cols-2">
       <div class="flex items-center gap-2">
         <span class="text-xs text-muted w-12">A</span>
         <PlayerSelect
@@ -36,7 +36,7 @@
       </div>
     </div>
 
-    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
       <PlayerSummary :name="a" :peerKpi="kpiB" :rwindow="rwindow" />
       <PlayerSummary :name="b" :peerKpi="kpiA" :rwindow="rwindow" />
     </div>
@@ -70,7 +70,7 @@ const dataB = usePlayerData(b);
 const kpiA = computed(() => dataA.kpi.value);
 const kpiB = computed(() => dataB.kpi.value);
 
-async function shareCurrent() {
+const shareCurrent = async (): Promise<void> => {
   try {
     const short = await createShareLink("compare", {
       a: a.value,
@@ -82,14 +82,14 @@ async function shareCurrent() {
   } catch {
     pushToast("共有リンクの作成に失敗しました", "error");
   }
-}
+};
 
-function swap() {
+const swap = (): void => {
   const tmp = a.value;
   a.value = b.value;
   b.value = tmp;
   pushToast("A/Bを入れ替えました", "success");
-}
+};
 
 onMounted(() => {
   const handler = (e: KeyboardEvent) => {

--- a/pages/labs/suggest.vue
+++ b/pages/labs/suggest.vue
@@ -1,0 +1,54 @@
+<template>
+  <section class="space-y-4">
+    <h1 class="text-2xl font-bold">Labs: サジェスト辞書管理</h1>
+    <p class="text-sm text-gray-400">サジェスト候補を編集します（KV seed:players）</p>
+    <textarea v-model="text" class="w-full h-60 rounded-lg border border-border bg-surface p-3 text-sm"></textarea>
+    <div class="flex gap-2">
+      <button
+        class="rounded-lg border border-border px-3 py-2 text-sm hover:text-text"
+        @click="load"
+      >
+        再読み込み
+      </button>
+      <button
+        class="rounded-lg border border-border px-3 py-2 text-sm hover:text-text"
+        @click="save"
+      >
+        保存
+      </button>
+    </div>
+    <div v-if="status" class="text-sm text-muted">{{ status }}</div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { getSuggestSeeds, saveSuggestSeeds } from "@/utils/api";
+
+const text = ref("");
+const status = ref("");
+
+const load = async (): Promise<void> => {
+  status.value = "";
+  try {
+    text.value = (await getSuggestSeeds()).join("\n");
+  } catch {
+    status.value = "読み込みに失敗しました";
+  }
+};
+
+const save = async (): Promise<void> => {
+  status.value = "";
+  try {
+    const seeds = text.value
+      .split(/\n+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    await saveSuggestSeeds(seeds);
+    status.value = "保存しました";
+  } catch {
+    status.value = "保存に失敗しました";
+  }
+};
+
+onMounted(load);
+</script>


### PR DESCRIPTION
## Summary
- centralize suggest dictionary API calls in `utils/api` and switch project helpers to arrow functions
- update labs suggest page to load/save seeds through new API helpers
- refactor rankings and compare methods to arrow functions for consistency

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896d7cf689083218df96c374a507b57