### PR TITLE
feat: rankings filters, compare swapping, player charts

### DIFF
--- a/components/DiffBadge.vue
+++ b/components/DiffBadge.vue
@@ -10,23 +10,16 @@
 </template>
 
 <script setup lang="ts">
+import { toneForDiff } from "~/utils/kpi";
+
 const props = withDefaults(
-  defineProps<{
-    delta: number;
-    percent?: boolean;
-    reverse?: boolean;
-  }>(),
-  { percent: true, reverse: false }
+  defineProps<{ delta: number; percent?: boolean; kpi: string }>(),
+  { percent: true }
 );
 
 const isZero = computed(() => Math.abs(props.delta) < 1e-9);
 const sign = computed(() => (props.delta > 0 ? "+" : ""));
-const tone = computed<"good" | "bad" | "neutral">(() => {
-  if (isZero.value) return "neutral";
-  const positiveIsGood = !props.reverse;
-  const good = props.delta > 0 ? positiveIsGood : !positiveIsGood;
-  return good ? "good" : "bad";
-});
+const tone = computed(() => toneForDiff(props.kpi, props.delta));
 const toneClass = computed(() =>
   tone.value === "good"
     ? "bg-[#04261f] text-[#2dd4bf] border border-[#124c43]"
@@ -39,5 +32,7 @@ const text = computed(() =>
     ? (Math.abs(props.delta) * 100).toFixed(1) + "%"
     : Math.abs(props.delta).toFixed(2)
 );
-const title = computed(() => (props.reverse ? "（値が小さいほど良い）" : ""));
+const title = computed(() =>
+  ["houju", "avgRank"].includes(props.kpi) ? "（値が小さいほど良い）" : ""
+);
 </script>

--- a/components/FilterChips.vue
+++ b/components/FilterChips.vue
@@ -74,18 +74,13 @@
 </template>
 
 <script setup lang="ts">
-type Mode = "this" | "prev" | "last30d" | "last90d" | "custom";
-type Table = "一般" | "上" | "特上" | "鳳凰";
-type Rule = "東南" | "東";
-type SortKey = "rate" | "games" | "name" | "rank";
-
-type Model = {
-  mode: Mode;
-  tableType: Table;
-  rule: Rule;
-  sortKey: SortKey;
-  favOnly: boolean;
-};
+import type {
+  Model,
+  Mode,
+  TableType as Table,
+  Rule,
+  SortKey,
+} from "~/types/rankings";
 
 const props = defineProps<{ modelValue: Model }>();
 const emit = defineEmits<{

--- a/components/FilterDrawer.vue
+++ b/components/FilterDrawer.vue
@@ -18,7 +18,21 @@
         <div class="space-y-5">
           <div>
             <div class="mb-1 text-xs text-muted">期間</div>
-            <DateRangePicker @update="onRange" />
+            <DateRangePicker @update="onUpdate" />
+            <div class="mt-2 flex gap-2 justify-end">
+              <button
+                class="rounded-lg border border-[#242A33] px-3 py-1 text-sm hover:text-text"
+                @click="apply"
+              >
+                適用
+              </button>
+              <button
+                class="rounded-lg border border-[#242A33] px-3 py-1 text-sm hover:text-text"
+                @click="reset"
+              >
+                リセット
+              </button>
+            </div>
           </div>
 
           <label class="flex items-center gap-2 text-sm">
@@ -56,11 +70,20 @@ const emit = defineEmits<{
   (e: "share"): void;
 }>();
 
+const range = ref({ mode: "this", from: "", to: "" });
+
 function close() {
   emit("update:open", false);
 }
-function onRange(p: { mode: string; from: string; to: string }) {
-  emit("range", p);
+function onUpdate(p: { mode: string; from: string; to: string }) {
+  range.value = p;
+}
+function apply() {
+  emit("range", range.value);
+}
+function reset() {
+  range.value = { mode: "this", from: "", to: "" };
+  emit("range", range.value);
 }
 
 const fav = computed({

--- a/components/PlayerSummary.vue
+++ b/components/PlayerSummary.vue
@@ -16,28 +16,28 @@
         :value="pct(kpi.agari)"
         :tone="toneForKpi('agari', kpi.agari)"
       >
-        <DiffBadge v-if="peer" :delta="kpi.agari - peer.agari" />
+        <DiffBadge v-if="peer" kpi="agari" :delta="kpi.agari - peer.agari" />
       </KpiCard>
       <KpiCard
         label="放銃率"
         :value="pct(kpi.houju)"
         :tone="toneForKpi('houju', kpi.houju)"
       >
-        <DiffBadge v-if="peer" :delta="kpi.houju - peer.houju" reverse />
+        <DiffBadge v-if="peer" kpi="houju" :delta="kpi.houju - peer.houju" />
       </KpiCard>
       <KpiCard
         label="立直率"
         :value="pct(kpi.riichi)"
         :tone="toneForKpi('riichi', kpi.riichi)"
       >
-        <DiffBadge v-if="peer" :delta="kpi.riichi - peer.riichi" />
+        <DiffBadge v-if="peer" kpi="riichi" :delta="kpi.riichi - peer.riichi" />
       </KpiCard>
       <KpiCard
         label="副露率"
         :value="pct(kpi.furo)"
         :tone="toneForKpi('furo', kpi.furo)"
       >
-        <DiffBadge v-if="peer" :delta="kpi.furo - peer.furo" />
+        <DiffBadge v-if="peer" kpi="furo" :delta="kpi.furo - peer.furo" />
       </KpiCard>
       <KpiCard
         label="平均順位"
@@ -46,9 +46,9 @@
       >
         <DiffBadge
           v-if="peer"
+          kpi="avgRank"
           :delta="kpi.avgRank - peer.avgRank"
           :percent="false"
-          reverse
         />
       </KpiCard>
     </div>
@@ -63,7 +63,7 @@
 
     <div class="grid gap-4 md:grid-cols-2">
       <RankTrendChart :ranks="visibleRanks" />
-      <RankPieChart :ranks="visibleRanks" />
+      <RankDonut :counts="rankCounts" />
     </div>
 
     <div>
@@ -118,6 +118,12 @@ const visibleRanks = computed<number[]>(() => {
   const arr = me.ranks.value ?? [];
   const w = props.rwindow ?? 120;
   return arr.slice(-w);
+});
+
+const rankCounts = computed(() => {
+  const c = [0, 0, 0, 0];
+  for (const r of visibleRanks.value) if (r >= 1 && r <= 4) c[r - 1]++;
+  return c;
 });
 
 // peer側KPI（差分表示用）

--- a/components/RankDonut.vue
+++ b/components/RankDonut.vue
@@ -8,7 +8,7 @@
 <script setup lang="ts">
 import { onMounted, onBeforeUnmount, ref, watch } from "vue";
 
-const props = defineProps<{ ranks: number[] }>();
+const props = defineProps<{ counts: number[] }>();
 
 let chart: any;
 const box = ref<HTMLElement | null>(null);
@@ -20,21 +20,16 @@ function getCss(name: string) {
     .trim();
 }
 
-function dist() {
-  const c = [0, 0, 0, 0, 0]; // ignore 0
-  for (const r of props.ranks) c[r]++;
-  return [
-    { name: "1位", value: c[1], itemStyle: { color: getCss("--jade") } },
-    { name: "2位", value: c[2], itemStyle: { color: getCss("--plum") } },
-    { name: "3位", value: c[3], itemStyle: { color: "var(--amber)" } },
-    { name: "4位", value: c[4], itemStyle: { color: getCss("--warn") } },
-  ];
-}
-
 async function render() {
   const echarts = await import("echarts");
   if (!box.value) return;
   chart = echarts.init(box.value);
+  const data = [
+    { value: props.counts[0], name: "1位", itemStyle: { color: getCss("--jade") } },
+    { value: props.counts[1], name: "2位", itemStyle: { color: getCss("--plum") } },
+    { value: props.counts[2], name: "3位", itemStyle: { color: "var(--amber)" } },
+    { value: props.counts[3], name: "4位", itemStyle: { color: getCss("--warn") } },
+  ];
   chart.setOption({
     tooltip: { trigger: "item", formatter: "{b}: {d}% ({c} 回)" },
     series: [
@@ -44,7 +39,7 @@ async function render() {
         avoidLabelOverlap: true,
         itemStyle: { borderColor: getCss("--surface"), borderWidth: 2 },
         label: { formatter: "{b}\n{d}%", color: getCss("--text") },
-        data: dist(),
+        data,
       },
     ],
     animationDuration: 250,
@@ -54,7 +49,8 @@ async function render() {
 onMounted(render);
 onBeforeUnmount(() => chart?.dispose?.());
 watch(
-  () => props.ranks,
-  () => chart?.dispose?.() || render()
+  () => props.counts,
+  () => chart?.dispose?.() || render(),
+  { deep: true }
 );
 </script>

--- a/composables/useRankingQuery.ts
+++ b/composables/useRankingQuery.ts
@@ -1,0 +1,88 @@
+import { resolveRange } from "~/utils/range";
+import type {
+  Model,
+  Mode,
+  TableType,
+  Rule,
+  SortKey,
+  SortDir,
+} from "~/types/rankings";
+
+const DEF: Model = {
+  mode: "this",
+  tableType: "特上",
+  rule: "東",
+  dense: false,
+  sortKey: "rate",
+  sortDir: "desc",
+  favOnly: false,
+};
+
+const tableTypes = new Set<TableType>(["一般", "上", "特上", "鳳凰"]);
+const rules = new Set<Rule>(["東", "東南"]);
+const sortKeys = new Set<SortKey>(["name", "rate", "games", "rank"]);
+const sortDirs = new Set<SortDir>(["asc", "desc"]);
+const modes = new Set<Mode>(["this", "prev", "last30d", "last90d", "custom"]);
+
+export function useRankingQuery() {
+  const route = useRoute();
+  const router = useRouter();
+  const model = ref<Model>({ ...DEF });
+
+  function clampFromQuery(q: Record<string, any>) {
+    const m = (q.mode ?? DEF.mode) as string;
+    model.value.mode = modes.has(m as Mode) ? (m as Mode) : DEF.mode;
+
+    if (model.value.mode === "custom") {
+      model.value.from = String(q.from || "").slice(0, 10) || undefined;
+      model.value.to = String(q.to || "").slice(0, 10) || undefined;
+    } else {
+      const r = resolveRange(model.value.mode);
+      model.value.from = r.from;
+      model.value.to = r.to;
+    }
+
+    const tt = decodeURIComponent(String(q.tableType || DEF.tableType));
+    model.value.tableType = tableTypes.has(tt as TableType)
+      ? (tt as TableType)
+      : DEF.tableType;
+
+    const rl = decodeURIComponent(String(q.rule || DEF.rule));
+    model.value.rule = rules.has(rl as Rule) ? (rl as Rule) : DEF.rule;
+
+    model.value.dense = String(q.dense) === "true";
+    model.value.favOnly = String(q.favOnly) === "true";
+
+    const sk = String(q.sortKey || DEF.sortKey);
+    model.value.sortKey = sortKeys.has(sk as SortKey)
+      ? (sk as SortKey)
+      : DEF.sortKey;
+
+    const sd = String(q.sortDir || DEF.sortDir);
+    model.value.sortDir = sortDirs.has(sd as SortDir)
+      ? (sd as SortDir)
+      : DEF.sortDir;
+  }
+
+  function syncToUrl(replace = true) {
+    const m = model.value;
+    const params: any = {
+      mode: m.mode,
+      tableType: m.tableType,
+      rule: m.rule,
+      dense: String(m.dense),
+      favOnly: String(!!m.favOnly),
+      sortKey: m.sortKey,
+      sortDir: m.sortDir,
+    };
+    if (m.mode === "custom") {
+      params.from = m.from || "";
+      params.to = m.to || "";
+    }
+    const q = new URLSearchParams(params).toString();
+    router.replace(`/rankings?${q}`);
+  }
+
+  watchEffect(() => clampFromQuery(route.query as any));
+  return { model, syncToUrl };
+}

--- a/composables/useSwipe.ts
+++ b/composables/useSwipe.ts
@@ -1,0 +1,37 @@
+import { ref, onMounted, onBeforeUnmount, type Ref } from "vue";
+
+export function useSwipe(
+  target: Ref<HTMLElement | null> | HTMLElement,
+  opts: { onSwipeLeft?: () => void; onSwipeRight?: () => void; threshold?: number } = {}
+) {
+  const elRef = ref(target as any);
+  const threshold = opts.threshold ?? 50;
+  let startX = 0;
+  let startY = 0;
+
+  function onDown(e: PointerEvent) {
+    startX = e.clientX;
+    startY = e.clientY;
+  }
+  function onUp(e: PointerEvent) {
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > threshold) {
+      if (dx < 0) opts.onSwipeLeft?.();
+      else opts.onSwipeRight?.();
+    }
+  }
+
+  onMounted(() => {
+    const el = elRef.value instanceof HTMLElement ? elRef.value : elRef.value?.value;
+    if (!el) return;
+    el.addEventListener("pointerdown", onDown);
+    el.addEventListener("pointerup", onUp);
+  });
+  onBeforeUnmount(() => {
+    const el = elRef.value instanceof HTMLElement ? elRef.value : elRef.value?.value;
+    if (!el) return;
+    el.removeEventListener("pointerdown", onDown);
+    el.removeEventListener("pointerup", onUp);
+  });
+}

--- a/pages/compare.vue
+++ b/pages/compare.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="space-y-4">
+  <section ref="root" class="space-y-4">
     <div class="flex items-center justify-between">
       <h1 class="text-2xl font-bold">プレイヤー比較</h1>
       <div class="flex flex-wrap items-center gap-2 text-sm text-muted">
@@ -45,6 +45,7 @@
 
 <script setup lang="ts">
 import { createShareLink } from "@/utils/share";
+import { useSwipe } from "~/composables/useSwipe";
 
 const route = useRoute();
 const router = useRouter();
@@ -53,6 +54,7 @@ const { push: pushToast } = useToast();
 const a = ref<string>(String(route.query.a ?? "Player_A"));
 const b = ref<string>(String(route.query.b ?? "Player_B"));
 const rwindow = ref<number>(Number(route.query.rwindow ?? 120) || 120);
+const root = ref<HTMLElement | null>(null);
 
 watch([a, b, rwindow], () => {
   router.replace({
@@ -88,8 +90,13 @@ const swap = (): void => {
   const tmp = a.value;
   a.value = b.value;
   b.value = tmp;
+  router.replace({
+    query: { ...route.query, a: a.value, b: b.value, rwindow: String(rwindow.value) },
+  });
   pushToast("A/Bを入れ替えました", "success");
 };
+
+useSwipe(root, { onSwipeLeft: swap, onSwipeRight: swap });
 
 onMounted(() => {
   const handler = (e: KeyboardEvent) => {

--- a/pages/player/[name].vue
+++ b/pages/player/[name].vue
@@ -42,7 +42,7 @@
 
     <div class="grid gap-4 md:grid-cols-2">
       <RankTrendChart :ranks="visibleRanks" />
-      <RankPieChart :ranks="visibleRanks" />
+      <RankDonut :counts="rankCounts" />
     </div>
 
     <div>
@@ -97,6 +97,12 @@ const ranks = ref<number[]>(
 const visibleRanks = computed(() => {
   const n = rwindow.value >= 9999 ? ranks.value.length : rwindow.value;
   return ranks.value.slice(-n);
+});
+
+const rankCounts = computed(() => {
+  const c = [0, 0, 0, 0];
+  for (const r of visibleRanks.value) if (r >= 1 && r <= 4) c[r - 1]++;
+  return c;
 });
 
 let chart: any;

--- a/types/rankings.ts
+++ b/types/rankings.ts
@@ -1,0 +1,17 @@
+export type Mode = "this" | "prev" | "last30d" | "last90d" | "custom"
+export type TableType = "一般" | "上" | "特上" | "鳳凰"
+export type Rule = "東" | "東南"
+export type SortKey = "name" | "rate" | "games" | "rank"
+export type SortDir = "asc" | "desc"
+
+export interface Model {
+  mode: Mode
+  from?: string // YYYY-MM-DD
+  to?: string   // YYYY-MM-DD
+  tableType: TableType
+  rule: Rule
+  dense: boolean
+  favOnly?: boolean
+  sortKey: SortKey
+  sortDir: SortDir
+}

--- a/utils/range.ts
+++ b/utils/range.ts
@@ -1,0 +1,37 @@
+export function todayYMD(d = new Date()): string {
+  const z = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${z(d.getMonth() + 1)}-${z(d.getDate())}`;
+}
+
+export function addDays(ymd: string, delta: number): string {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + delta);
+  return todayYMD(dt);
+}
+
+// モード→from/to
+export function resolveRange(mode: string, now = new Date()) {
+  const y = now.getFullYear(),
+    m = now.getMonth();
+  const firstThis = new Date(y, m, 1);
+  const firstPrev = new Date(y, m - 1, 1);
+  const lastPrev = new Date(y, m, 0); // 前月末日
+  const toYMD = todayYMD(now);
+  const firstThisYMD = todayYMD(firstThis);
+  const firstPrevYMD = todayYMD(firstPrev);
+  const lastPrevYMD = todayYMD(lastPrev);
+
+  switch (mode) {
+    case "this":
+      return { from: firstThisYMD, to: toYMD };
+    case "prev":
+      return { from: firstPrevYMD, to: lastPrevYMD };
+    case "last30d":
+      return { from: addDays(toYMD, -29), to: toYMD };
+    case "last90d":
+      return { from: addDays(toYMD, -89), to: toYMD };
+    default:
+      return {};
+  }
+}


### PR DESCRIPTION
## Summary
- add shared ranking model and URL-sync composable for custom ranges and favorites
- implement Alt+S swap with mobile swipe on compare page
- centralize KPI diff tone logic and add rank trend/donut charts for players

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896e638b48083218d562893d3afb9be