### PR TITLE
useRecent をアロー関数で再実装

### DIFF
--- a/composables/useRecent.ts
+++ b/composables/useRecent.ts
@@ -1,4 +1,7 @@
-export function useRecent() {
+export const useRecent = (): {
+  recent: Ref<string[]>;
+  addRecent: (name: string) => void;
+} => {
   const key = "paiviz:recent";
   const recent = ref<string[]>([]);
   if (process.client) {
@@ -7,10 +10,12 @@ export function useRecent() {
       if (raw) recent.value = JSON.parse(raw);
     } catch {}
   }
-  function addRecent(name: string) {
+  const addRecent = (name: string): void => {
     const set = new Set([name, ...recent.value]);
     recent.value = Array.from(set).slice(0, 20);
-    if (process.client) localStorage.setItem(key, JSON.stringify(recent.value));
-  }
+    if (process.client) {
+      localStorage.setItem(key, JSON.stringify(recent.value));
+    }
+  };
   return { recent, addRecent };
-}
+};


### PR DESCRIPTION
## Summary
- `useRecent` をアロー関数として再実装し型を明示
- recent データを localStorage に保存する際のガードを整理

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689705ce2ca08321b828cfa15ece15a8