### PR TITLE
お気に入り保存をクライアント側に限定

### DIFF
--- a/composables/useFavorites.ts
+++ b/composables/useFavorites.ts
@@ -7,7 +7,11 @@ const load = () => {
     favs.value = new Set(JSON.parse(s || '[]'))
   } catch { favs.value = new Set() }
 }
-const save = () => localStorage.setItem(KEY, JSON.stringify([...favs.value]))
+const save = (): void => {
+  if (process.client) {
+    localStorage.setItem(KEY, JSON.stringify([...favs.value]))
+  }
+}
 
 export const useFavorites = () => {
   if (process.client && favs.value.size === 0) load()


### PR DESCRIPTION
## Summary
- ガードを追加し、`localStorage` 操作をクライアント側のみに限定

## Testing
- `npm run build`
- Node で `process.client = false` の状態で `toggle` を実行し例外が発生しないことを確認

------
https://chatgpt.com/codex/tasks/task_e_689705cc25088321b0c2d862f47447b8