### PR TITLE
比較ページにスパークラインとドーナツ追加

### DIFF
--- a/components/KpiDiffTable.vue
+++ b/components/KpiDiffTable.vue
@@ -2,7 +2,11 @@
   <div class="rounded-2xl border border-[#242A33] bg-[#161A20]">
     <div class="border-b border-[#242A33] px-4 py-2 text-sm text-gray-300">KPI差分</div>
     <div class="divide-y divide-[#242A33]">
-      <div v-for="row in rows" :key="row.key" class="grid grid-cols-12 items-center px-4 py-2 text-sm">
+      <div
+        v-for="row in rows"
+        :key="row.key"
+        class="grid grid-cols-12 items-center px-4 py-2 text-sm"
+      >
         <div class="col-span-3 text-gray-400">{{ row.label }}</div>
         <div class="col-span-4">
           <span :class="toneClass(row.aTone)">{{ row.aText }}</span>
@@ -19,30 +23,42 @@
 </template>
 
 <script setup lang="ts">
-type KPI = { agari:number; houju:number; riichi:number; furo:number; avgRank:number }
-const props = defineProps<{ a: KPI; b: KPI }>()
-const { toneForKpi, pct } = await import('~/utils/kpi')
+type KPI = { agari: number; houju: number; riichi: number; furo: number; avgRank: number };
+const props = defineProps<{ a: KPI; b: KPI; highlight?: boolean }>();
+const { toneForKpi, pct } = await import('~/utils/kpi');
 
 const defs = [
-  { key:'agari',   label:'和了率',   fmt:(v:number)=>pct(v) },
-  { key:'houju',   label:'放銃率',   fmt:(v:number)=>pct(v) },
-  { key:'riichi',  label:'立直率',   fmt:(v:number)=>pct(v) },
-  { key:'furo',    label:'副露率',   fmt:(v:number)=>pct(v) },
-  { key:'avgRank', label:'平均順位', fmt:(v:number)=>v.toFixed(2) },
-] as const
+  { key: 'agari', label: '和了率', fmt: (v: number) => pct(v) },
+  { key: 'houju', label: '放銃率', fmt: (v: number) => pct(v) },
+  { key: 'riichi', label: '立直率', fmt: (v: number) => pct(v) },
+  { key: 'furo', label: '副露率', fmt: (v: number) => pct(v) },
+  { key: 'avgRank', label: '平均順位', fmt: (v: number) => v.toFixed(2) },
+] as const;
 
-const rows = computed(() => defs.map(d => {
-  const ak = (props.a as any)[d.key] ?? 0
-  const bk = (props.b as any)[d.key] ?? 0
-  const delta = ak - bk
-  return {
-    key: d.key, label: d.label, delta,
-    aText: d.fmt(ak), bText: d.fmt(bk),
-    aTone: toneForKpi(d.key, ak), bTone: toneForKpi(d.key, bk)
-  }
-}))
+const rows = computed(() =>
+  defs.map((d) => {
+    const ak = (props.a as any)[d.key] ?? 0;
+    const bk = (props.b as any)[d.key] ?? 0;
+    const delta = ak - bk;
+    return {
+      key: d.key,
+      label: d.label,
+      delta,
+      aText: d.fmt(ak),
+      bText: d.fmt(bk),
+      aTone: toneForKpi(d.key, ak),
+      bTone: toneForKpi(d.key, bk),
+    };
+  })
+);
 
-const arrow = (n:number) => n === 0 ? '–' : (n > 0 ? '▶' : '◀')
-const diffClass = (n:number) => n === 0 ? 'text-gray-400' : (n > 0 ? 'text-teal-400' : 'text-rose-400')
-const toneClass = (t:'good'|'bad'|'neutral') => t === 'good' ? 'text-teal-300' : t === 'bad' ? 'text-rose-300' : 'text-gray-300'
+const arrow = (n: number) => (n === 0 ? '–' : n > 0 ? '▶' : '◀');
+const diffClass = (n: number) => {
+  if (props.highlight === false) return 'text-gray-400';
+  return n === 0 ? 'text-gray-400' : n > 0 ? 'text-teal-400' : 'text-rose-400';
+};
+const toneClass = (t: 'good' | 'bad' | 'neutral') => {
+  if (props.highlight === false) return 'text-gray-300';
+  return t === 'good' ? 'text-teal-300' : t === 'bad' ? 'text-rose-300' : 'text-gray-300';
+};
 </script>

--- a/components/RankDonutMini.vue
+++ b/components/RankDonutMini.vue
@@ -1,0 +1,68 @@
+<template>
+  <div ref="box" class="relative h-24 w-24" @click="toggle">
+    <div
+      v-if="!hasData"
+      class="flex h-full items-center justify-center rounded bg-[#242A33] text-xs text-muted"
+    >
+      データなし
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, ref, watch, computed } from 'vue';
+
+const props = defineProps<{
+  dist: { first: number; second: number; third: number; fourth: number };
+}>();
+const box = ref<HTMLElement | null>(null);
+let chart: any;
+const showLast = ref(false);
+const total = computed(
+  () => props.dist.first + props.dist.second + props.dist.third + props.dist.fourth
+);
+const hasData = computed(() => total.value > 0);
+
+const render = async (): Promise<void> => {
+  if (!box.value || !hasData.value) return;
+  const echarts = await import('echarts');
+  chart = echarts.init(box.value);
+  const data = [
+    { value: props.dist.first, name: '1位', itemStyle: { color: '#14B8A6' } },
+    { value: props.dist.second, name: '2位', itemStyle: { color: '#6B7280' } },
+    { value: props.dist.third, name: '3位', itemStyle: { color: '#9CA3AF' } },
+    { value: props.dist.fourth, name: '4位', itemStyle: { color: '#F43F5E' } },
+  ];
+  const topRate = total.value ? ((props.dist.first / total.value) * 100).toFixed(0) : '0';
+  const lastRate = total.value ? ((props.dist.fourth / total.value) * 100).toFixed(0) : '0';
+  chart.setOption({
+    title: {
+      text: showLast.value ? `${lastRate}%` : `${topRate}%`,
+      subtext: showLast.value ? 'ラス率' : 'Top率',
+      left: 'center',
+      top: 'center',
+      textStyle: { color: '#fff', fontSize: 14 },
+      subtextStyle: { color: '#9CA3AF', fontSize: 12 },
+    },
+    tooltip: { trigger: 'item', formatter: '{b}: {d}% ({c})' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['60%', '90%'],
+        label: { show: false },
+        data,
+        itemStyle: { borderColor: '#161A20', borderWidth: 2 },
+      },
+    ],
+    animation: false,
+  });
+};
+
+const toggle = (): void => {
+  showLast.value = !showLast.value;
+};
+
+useOnVisible(box, () => render());
+onBeforeUnmount(() => chart?.dispose?.());
+watch([() => props.dist, showLast], () => chart?.dispose?.() || render(), { deep: true });
+</script>

--- a/components/RankSparkline.vue
+++ b/components/RankSparkline.vue
@@ -1,0 +1,63 @@
+<template>
+  <div ref="box" class="h-14 w-full md:h-20">
+    <div
+      v-if="!hasData"
+      class="flex h-full items-center justify-center rounded bg-[#242A33] text-xs text-muted"
+    >
+      データなし
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, ref, watch, computed } from 'vue';
+
+const props = defineProps<{ ranks: number[] }>();
+const box = ref<HTMLElement | null>(null);
+let chart: any;
+const hasData = computed(() => Array.isArray(props.ranks) && props.ranks.length > 0);
+
+const render = async (): Promise<void> => {
+  if (!box.value || !hasData.value) return;
+  const echarts = await import('echarts');
+  chart = echarts.init(box.value);
+  const data = props.ranks;
+  chart.setOption({
+    grid: { left: 2, right: 2, top: 2, bottom: 2 },
+    xAxis: { type: 'category', show: false, data: data.map((_, i) => i) },
+    yAxis: { type: 'value', min: 1, max: 4, inverse: true, splitNumber: 3, show: false },
+    series: [
+      {
+        type: 'line',
+        data,
+        showSymbol: false,
+        lineStyle: { color: '#14B8A6', width: 1.5 },
+        markPoint: {
+          data: [
+            {
+              coord: [data.length - 1, data[data.length - 1]],
+              symbol: 'circle',
+              symbolSize: 6,
+              itemStyle: { color: '#14B8A6' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'line',
+        data: Array(data.length).fill(2.5),
+        showSymbol: false,
+        lineStyle: { color: '#374151', width: 1, type: 'dashed' },
+      },
+    ],
+    animation: false,
+  });
+};
+
+useOnVisible(box, () => render());
+onBeforeUnmount(() => chart?.dispose?.());
+watch(
+  () => props.ranks,
+  () => chart?.dispose?.() || render()
+);
+</script>

--- a/composables/useCompare.ts
+++ b/composables/useCompare.ts
@@ -1,12 +1,12 @@
-import { getPlayerKpi, type KPI } from '~/utils/kpi';
+import { getPlayerStats, type PlayerStats } from '~/utils/kpi';
 
 /** 比較ページ用のKPI取得と状態管理 */
 export const useCompare = () => {
   const route = useRoute();
   const aName = computed(() => String(route.query.a || ''));
   const bName = computed(() => String(route.query.b || ''));
-  const a = ref<KPI | null>(null);
-  const b = ref<KPI | null>(null);
+  const a = ref<PlayerStats | null>(null);
+  const b = ref<PlayerStats | null>(null);
   const loading = ref(false);
   const errored = ref(false);
 
@@ -14,9 +14,12 @@ export const useCompare = () => {
     loading.value = true;
     errored.value = false;
     try {
-      const [ka, kb] = await Promise.all([getPlayerKpi(aName.value), getPlayerKpi(bName.value)]);
-      a.value = ka;
-      b.value = kb;
+      const [sa, sb] = await Promise.all([
+        getPlayerStats(aName.value),
+        getPlayerStats(bName.value),
+      ]);
+      a.value = sa;
+      b.value = sb;
     } catch {
       errored.value = true;
       a.value = null;

--- a/pages/admin/seeds.vue
+++ b/pages/admin/seeds.vue
@@ -2,17 +2,38 @@
   <section class="mx-auto max-w-3xl space-y-6">
     <h1 class="text-2xl font-bold">Seeds 管理</h1>
 
-    <div class="rounded-2xl border border-[#242A33] bg-[#161A20] p-4">
-      <div class="mb-3 text-sm text-muted">サジェスト候補（KV seed:players）</div>
+    <div class="space-y-4 rounded-2xl border border-[#242A33] bg-[#161A20] p-4">
+      <div class="flex gap-2">
+        <input ref="fileRef" type="file" class="hidden" @change="onFile" />
+        <button
+          class="rounded-lg bg-teal-600 px-3 py-2 text-sm text-white"
+          @click="() => fileRef?.click()"
+        >
+          CSVインポート
+        </button>
+        <button class="rounded-lg bg-teal-600 px-3 py-2 text-sm text-white" @click="exportCsv">
+          CSVエクスポート
+        </button>
+      </div>
+      <textarea
+        v-model="bulk"
+        class="h-32 w-full rounded-xl bg-[#0F1115] p-2 text-sm ring-1 ring-[#242A33]"
+        placeholder="一括登録 (1行=1名, #始まりはコメント)"
+      />
       <div class="flex gap-2">
         <input
           v-model="name"
           class="w-full rounded-xl bg-[#0F1115] px-3 py-2 ring-1 ring-[#242A33]"
           placeholder="プレイヤー名を追加"
         />
-        <button class="rounded-lg bg-teal-600 px-3 py-2 text-sm" @click="add">追加</button>
+        <button class="rounded-lg bg-teal-600 px-3 py-2 text-sm text-white" @click="add">
+          追加
+        </button>
+        <button class="rounded-lg bg-teal-600 px-3 py-2 text-sm text-white" @click="bulkAdd">
+          一括登録
+        </button>
       </div>
-      <div class="mt-3">
+      <div>
         <div class="text-xs text-muted">一覧（{{ items.length }}件）</div>
         <ul class="mt-1 divide-y divide-[#242A33]">
           <li v-for="it in items" :key="it.name" class="flex items-center justify-between py-2">
@@ -34,10 +55,13 @@
 
 <script setup lang="ts">
 import { listSeeds, addSeed, deleteSeed } from '~/utils/api';
+import { downloadCsv } from '~/utils/csv';
 const items = ref<{ name: string }[]>([]);
 const name = ref('');
+const bulk = ref('');
+const fileRef = ref<HTMLInputElement | null>(null);
+const toast = useToast();
 
-// 最低限の簡易ガード：管理トークンを毎回要求（Pages Functions 側で検証）
 const admin = ref('');
 onMounted(async () => {
   admin.value = localStorage.getItem('paiviz_admin') || prompt('ADMIN_TOKEN を入力') || '';
@@ -45,31 +69,72 @@ onMounted(async () => {
   await reload();
 });
 
-async function reload() {
+const reload = async (): Promise<void> => {
   try {
-    items.value = await listSeeds();
+    const res = await listSeeds();
+    const set = new Set(res.map((r) => r.name.trim()).filter(Boolean));
+    items.value = [...set].sort((a, b) => a.localeCompare(b)).map((n) => ({ name: n }));
   } catch {
     items.value = [];
   }
-}
-async function add() {
+};
+
+const saveNames = async (names: string[]): Promise<void> => {
+  const before = items.value.length;
+  for (const n of names) {
+    try {
+      await addSeed(n, admin.value as any);
+    } catch {
+      toast.push(`登録失敗: ${n}`);
+    }
+  }
+  await reload();
+  const diff = items.value.length - before;
+  toast.push(`追加 ${diff}件 (計${items.value.length}件)`);
+};
+
+const add = async (): Promise<void> => {
   const n = name.value.trim();
   if (!n) return;
-  try {
-    await addSeed(n, admin.value as any);
-    name.value = '';
-    await reload();
-  } catch {
-    /* ignore */
-  }
-}
-async function del(n: string) {
+  await saveNames([n]);
+  name.value = '';
+};
+
+const bulkAdd = async (): Promise<void> => {
+  const lines = bulk.value.split(/\r?\n/);
+  const names = lines.map((l) => l.trim()).filter((l) => l && !l.startsWith('#'));
+  bulk.value = '';
+  await saveNames(names);
+};
+
+const del = async (n: string): Promise<void> => {
   if (!confirm(`${n} を削除しますか？`)) return;
   try {
     await deleteSeed(n, admin.value as any);
     await reload();
+    toast.push('削除しました');
   } catch {
-    /* ignore */
+    toast.push('削除に失敗しました');
   }
-}
+};
+
+const exportCsv = (): void => {
+  const content = ['name', ...items.value.map((i) => i.name)].join('\n');
+  downloadCsv('seeds.csv', content);
+};
+
+const onFile = async (e: Event): Promise<void> => {
+  const file = (e.target as HTMLInputElement).files?.[0];
+  if (!file) return;
+  const text = await file.text();
+  const lines = text.replace(/^\uFEFF/, '').split(/\r?\n/);
+  const names: string[] = [];
+  const hasHeader = lines[0]?.toLowerCase().includes('name');
+  for (let i = hasHeader ? 1 : 0; i < lines.length; i++) {
+    const col = lines[i].split(',')[0]?.replace(/"/g, '').trim();
+    if (col) names.push(col);
+  }
+  await saveNames(names);
+  (e.target as HTMLInputElement).value = '';
+};
 </script>


### PR DESCRIPTION
## Summary
- add deterministic PlayerStats with recent ranks and distribution
- enhance compare page with sparkline, rank donut, shortcuts, and sharing
- expand admin seeds with CSV import/export and bulk registration

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689729f3b898832194d5ce6596d88aae