### PR TITLE
ランキングの安定ソートとARIA対応を改善

### DIFF
--- a/components/VirtualTable.vue
+++ b/components/VirtualTable.vue
@@ -1,15 +1,31 @@
 <template>
-  <div class="rounded-2xl border border-[#242A33] bg-[#161A20]">
+  <div class="rounded-2xl border border-[#242A33] bg-[#161A20]" role="grid">
     <!-- ヘッダ -->
     <div
       class="sticky top-0 z-10 grid border-b border-[#242A33] bg-[#161A20] text-xs text-gray-400"
       :style="{ gridTemplateColumns: colTemplate }"
+      role="row"
     >
-      <div v-for="c in columns" :key="c.key" class="px-3 py-2">{{ c.label }}</div>
+      <div
+        v-for="c in columns"
+        :key="c.key"
+        class="px-3 py-2"
+        role="columnheader"
+        :aria-sort="
+          props.sortKey === c.key ? (props.sortDir === 'asc' ? 'ascending' : 'descending') : 'none'
+        "
+      >
+        {{ c.label }}
+      </div>
     </div>
 
     <!-- ビューポート -->
-    <div ref="viewport" class="relative overflow-auto" :style="{ height: height + 'px' }" @scroll="onScroll">
+    <div
+      ref="viewport"
+      class="relative overflow-auto"
+      :style="{ height: height + 'px' }"
+      @scroll="onScroll"
+    >
       <!-- 全体高（ダミー） -->
       <div :style="{ height: totalHeight + 'px' }"></div>
       <!-- 可視領域 -->
@@ -22,7 +38,9 @@
           role="row"
         >
           <div v-for="c in columns" :key="c.key" class="px-3">
-            <component :is="c.render ?? 'span'" v-bind="buildCellProps(row, c)">{{ row[c.key] }}</component>
+            <component :is="c.render ?? 'span'" v-bind="buildCellProps(row, c)">{{
+              row[c.key]
+            }}</component>
           </div>
         </div>
       </div>
@@ -35,46 +53,54 @@
 </template>
 
 <script setup lang="ts">
-type Col = { key: string; label: string; width?: string; render?: any }
+type Col = { key: string; label: string; width?: string; render?: any };
 const props = defineProps<{
-  rows: any[]
-  columns: Col[]
-  rowHeight?: number
-  height?: number
-  keyField?: string
-}>()
+  rows: any[];
+  columns: Col[];
+  rowHeight?: number;
+  height?: number;
+  keyField?: string;
+  sortKey?: string;
+  sortDir?: 'asc' | 'desc';
+}>();
 
-const rowHeight = props.rowHeight ?? 44
-const height = props.height ?? 480
-const keyField = props.keyField ?? 'name'
+const rowHeight = props.rowHeight ?? 44;
+const height = props.height ?? 480;
+const keyField = props.keyField ?? 'name';
 
-const viewport = ref<HTMLElement|null>(null)
-const start = ref(0)
-const end = ref(0)
-const buffer = 6 // 上下に余分に描画
-const colTemplate = computed(() => (props.columns ?? []).map(c => c.width ?? '1fr').join(' '))
+const viewport = ref<HTMLElement | null>(null);
+const start = ref(0);
+const end = ref(0);
+const buffer = 6; // 上下に余分に描画
+const colTemplate = computed(() => (props.columns ?? []).map((c) => c.width ?? '1fr').join(' '));
 
-const totalHeight = computed(() => (props.rows?.length ?? 0) * rowHeight)
-const page = Math.ceil(height / rowHeight)
+const totalHeight = computed(() => (props.rows?.length ?? 0) * rowHeight);
+const page = Math.ceil(height / rowHeight);
 
 const clamp = (): void => {
-  const v = viewport.value
-  const len = props.rows?.length ?? 0
-  if (!v || !len) { start.value = 0; end.value = 0; return }
-  const s = Math.floor(v.scrollTop / rowHeight)
-  start.value = Math.max(0, s - buffer)
-  end.value = Math.min(len, s + page + buffer)
-}
-const onScroll = (): void => clamp()
-onMounted(() => { clamp(); window.addEventListener('resize', clamp) })
-onBeforeUnmount(() => window.removeEventListener('resize', clamp))
+  const v = viewport.value;
+  const len = props.rows?.length ?? 0;
+  if (!v || !len) {
+    start.value = 0;
+    end.value = 0;
+    return;
+  }
+  const s = Math.floor(v.scrollTop / rowHeight);
+  start.value = Math.max(0, s - buffer);
+  end.value = Math.min(len, s + page + buffer);
+};
+const onScroll = (): void => clamp();
+onMounted(() => {
+  clamp();
+  window.addEventListener('resize', clamp);
+});
+onBeforeUnmount(() => window.removeEventListener('resize', clamp));
 
-const offsetY = computed(() => start.value * rowHeight)
-const visibleRows = computed(() => props.rows?.slice(start.value, end.value) ?? [])
+const offsetY = computed(() => start.value * rowHeight);
+const visibleRows = computed(() => props.rows?.slice(start.value, end.value) ?? []);
 
-const buildCellProps = (row:any, c:Col) => ({ row, value: row[c.key], col: c })
+const buildCellProps = (row: any, c: Col) => ({ row, value: row[c.key], col: c });
 
 // 公開メソッド：現在の可視行（CSVなどで利用したい場合）
-defineExpose({ getVisible: () => visibleRows.value })
+defineExpose({ getVisible: () => visibleRows.value });
 </script>
-


### PR DESCRIPTION
## Summary
- VirtualTableに`role="grid"`と`aria-sort`を追加しアクセシビリティを向上
- ランキングの並び替えを安定ソート化し、名前/対局数を含む複合キーで比較

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689730993ef48321b2e0678180bdc83d