### PR TITLE
Web Workerのメッセージをプレーンデータ化

### DIFF
--- a/pages/rankings.vue
+++ b/pages/rankings.vue
@@ -54,7 +54,7 @@ const genRows = (): Row[] => {
   }));
 };
 
-const recalc = () => {
+const recalc = (): void => {
   if (!worker) return;
   loading.value = true;
   const sortKeys: RankRequest['sort']['keys'] = [];
@@ -66,8 +66,8 @@ const recalc = () => {
   else sortKeys.push({ key: 'rate', dir: 'desc' });
   sortKeys.push({ key: 'games', dir: 'desc' }, { key: 'name', dir: 'asc' });
   const msg: RankRequest = {
-    rows: rows.value,
-    filter: { favOnly: model.value.favOnly, favs: favList.value },
+    rows: rows.value.map((r) => ({ ...r })),
+    filter: { favOnly: model.value.favOnly, favs: [...favList.value] },
     sort: { keys: sortKeys },
   };
   worker.postMessage(msg);


### PR DESCRIPTION
## Summary
- Web Workerへ送信するランキングデータをプレーンオブジェクトに変換し、`postMessage`の構造化複製エラーを解消

## Testing
- `npm run lint`
- `npm run format` *(style issues detected but command executed)*

------
https://chatgpt.com/codex/tasks/task_e_689743651adc8321a730c9bf21faff1a