### PR TITLE
ランキングにダミーデータを供給してトップ抜粋を表示

### DIFF
--- a/composables/useFavorites.ts
+++ b/composables/useFavorites.ts
@@ -1,12 +1,15 @@
 const KEY = 'paiviz:favs';
 const favs = ref<Set<string>>(new Set());
 
-const load = () => {
+const DEFAULT = ['P-0001', 'P-0002', 'P-0003', 'P-0004', 'P-0005'];
+const load = (): void => {
   try {
     const s = localStorage.getItem(KEY);
-    favs.value = new Set(JSON.parse(s || '[]'));
+    const arr = JSON.parse(s || '[]');
+    const list = Array.isArray(arr) && arr.length ? arr : DEFAULT;
+    favs.value = new Set(list);
   } catch {
-    favs.value = new Set();
+    favs.value = new Set(DEFAULT);
   }
 };
 const save = (): void => {

--- a/pages/rankings.vue
+++ b/pages/rankings.vue
@@ -45,10 +45,10 @@ let worker: Worker | null = null;
 const { list: favList } = useFavorites();
 const FavStar = resolveComponent('FavStar');
 
-const recalc = (): void => {
+const recalc = async (): Promise<void> => {
   if (!worker) return;
   loading.value = true;
-  rows.value = getRankingRows(model.value);
+  rows.value = await getRankingRows(model.value);
   const sortKeys: RankRequest['sort']['keys'] = [];
   const sk = model.value.sortKey;
   const dir = model.value.sortDir;
@@ -74,14 +74,18 @@ if (process.client) {
 }
 
 onMounted(() => {
-  recalc();
+  void recalc();
 });
 
 watch(
   () => ({ ...model.value }),
-  () => recalc()
+  () => {
+    void recalc();
+  }
 );
-watch(favList, () => recalc());
+watch(favList, () => {
+  void recalc();
+});
 
 // CSV
 import { toCsv, downloadCsv } from '~/utils/csv';

--- a/providers/rankings.ts
+++ b/providers/rankings.ts
@@ -1,34 +1,32 @@
 import type { TableType, Rule } from '~/types/rankings';
 import type { RankRow } from '~/workers/rankWorker';
 
-export type RankingRow = RankRow & { trend: string; tableType: TableType; rule: Rule };
+export type RankingRow = RankRow & { spark: number[]; tableType: TableType; rule: Rule };
 
-const TABLE_TYPES: TableType[] = ['一般', '上', '特上', '鳳凰'];
-const RULES: Rule[] = ['東', '東南'];
-const TRENDS = ['↗︎', '→', '↘︎'] as const;
-
-const ALL_ROWS: RankingRow[] = Array.from({ length: 500 }, (_, i) => {
-  const tableType = TABLE_TYPES[i % TABLE_TYPES.length];
-  const rule = RULES[Math.floor(i / TABLE_TYPES.length) % RULES.length];
-  const rate = 1800 + ((i * 13) % 401);
-  const games = 50 + ((i * 17) % 451);
-  return {
-    rank: i + 1,
-    name: `P-${(i + 1).toString().padStart(4, '0')}`,
-    rate,
-    games,
-    trend: TRENDS[i % TRENDS.length],
-    tableType,
-    rule,
-  };
+const ALL_ROWS: RankingRow[] = Array.from({ length: 400 }, (_, i) => {
+  const name = `P-${(i + 1).toString().padStart(4, '0')}`;
+  const rate = 1800 + ((i * 37) % 401);
+  const games = 40 + ((i * 23) % 361);
+  let tableType: TableType;
+  if (i < 280) tableType = '特上';
+  else if (i < 320) tableType = '一般';
+  else if (i < 360) tableType = '上';
+  else tableType = '鳳凰';
+  const rule: Rule = i % 10 < 6 ? '東' : '東南';
+  const len = 16 + (i % 17);
+  const spark = Array.from({ length: len }, (_, j) => ((i + j) % 4) + 1);
+  return { name, rate, games, spark, tableType, rule };
 });
 
 /**
- * 指定した卓・ルールに該当するランキング行を取得する。
+ * ランキング行を取得する（将来の実データ差し替えポイント）。
  * @param query フィルタ条件
  * @returns ランキング行の配列
  */
-export const getRankingRows = (query: { tableType: TableType; rule: Rule }): RankingRow[] =>
+export const getRankingRows = async (query: {
+  tableType: TableType;
+  rule: Rule;
+}): Promise<RankingRow[]> =>
   ALL_ROWS.filter((r) => r.tableType === query.tableType && r.rule === query.rule).map(
     (r, idx) => ({ ...r, rank: idx + 1 })
   );


### PR DESCRIPTION
## Summary
- generate deterministic ranking rows via `getRankingRows`
- show /rankings data from provider and expose top10 excerpt on home
- seed default favorites to keep "お気に入りのみ" results

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897538379088321a771080abfc425da